### PR TITLE
[기능] TextField 컴포넌트 구현

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,19 @@
+name: Check PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        run: |
+          echo "PR title: ${{ github.event.pull_request.title }}"
+          title="${{ github.event.pull_request.title }}"
+          if [[ ! "$title" =~ ^\[(기능|수정|버그|리팩토링|문서|설정|삭제)\]\  ]]; then
+            echo "❌ PR 제목이 형식에 맞지 않습니다. '[기능] ...' 형태로 작성하세요."
+            exit 1
+          fi
+        shell: bash

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { HTMLAttributes, useState } from 'react';
 
 interface Option {
   label: string;
   value: string;
 }
 
-interface DropdownProps {
+interface DropdownProps extends HTMLAttributes<HTMLDivElement> {
   placeholder: string;
   options: Option[];
   onOptionSelect?: (value: string) => void;

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -24,18 +24,14 @@ export default function TextField({
           {label}
         </label>
       )}
-      <div className="relative w-full">
-        {icon && (
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            {icon}
-          </div>
-        )}
+      <div
+        className={`flex items-center w-full border rounded-md px-3 py-2 focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500 ${className}`}
+      >
+        {icon && <div className="mr-2 text-gray-400">{icon}</div>}
         <input
           id={id}
           ref={ref}
-          className={`w-full border rounded-md px-3 py-2 ${
-            icon ? 'pl-10' : ''
-          } text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 ${className}`}
+          className="flex-1 bg-transparent outline-none text-sm text-gray-900 placeholder-gray-400"
           {...props}
         />
       </div>

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -33,7 +33,9 @@ export default function TextField({
         <input
           id={id}
           ref={ref}
-          className={`w-full border rounded-md px-3 py-2 pl-10 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 ${className}`}
+          className={`w-full border rounded-md px-3 py-2 ${
+            icon ? 'pl-10' : ''
+          } text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 ${className}`}
           {...props}
         />
       </div>

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -1,0 +1,42 @@
+import { InputHTMLAttributes } from 'react';
+
+interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  icon?: React.ReactNode;
+  ref?: React.Ref<HTMLInputElement>;
+}
+
+export default function TextField({
+  label,
+  icon,
+  id,
+  className = '',
+  ref,
+  ...props
+}: TextFieldProps) {
+  return (
+    <div className="w-full">
+      {label && (
+        <label
+          htmlFor={id}
+          className="block mb-1 text-sm font-medium text-gray-700"
+        >
+          {label}
+        </label>
+      )}
+      <div className="relative w-full">
+        {icon && (
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            {icon}
+          </div>
+        )}
+        <input
+          id={id}
+          ref={ref}
+          className={`w-full border rounded-md px-3 py-2 pl-10 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 ${className}`}
+          {...props}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용

- dropdown 컴포넌트가 HTMLAttributes<HTMLDivElement>를 확장하도록 적용
- TextField 컴포넌트 구현
- PR title을 확인하는 워크플로우 추가

## 참고 사항

- TextField는 icon을 ReactNode로, ref를 Ref<HTMLInputElement>로 받아 기능연결을 할 수 있도록 만들었습니다.
- PR 제목이 "$title" =~ ^\[(기능|수정|버그|리팩토링|문서|설정|삭제)\]\  ]]; 를 만족하지 못한다면 PR 요청을 할 수 없도록 만들었습니다.
