### PR TITLE
[수정] 공통 모달 컴포넌트 버튼 수정

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -39,7 +39,7 @@ const Button: React.FC<ButtonProps> = ({
   return (
     <button
       type={type}
-      className={`inline-flex items-center gap-2 px-5 py-2 rounded-lg font-medium transition-colors focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed ${colorClassMap[color]} ${className}`.trim()}
+      className={`inline-flex items-center gap-2 px-5 py-2 rounded-sm font-medium transition-colors focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed ${colorClassMap[color]} ${className}`.trim()}
       onClick={onClick}
       disabled={disabled}
     >

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -39,7 +39,7 @@ const Button: React.FC<ButtonProps> = ({
   return (
     <button
       type={type}
-      className={`inline-flex items-center gap-2 px-5 py-2 rounded-sm font-medium transition-colors focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed ${colorClassMap[color]} ${className}`.trim()}
+      className={`inline-flex items-center gap-2 px-5 py-2 rounded-sm cursor-pointer font-medium transition-colors focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed ${colorClassMap[color]} ${className}`.trim()}
       onClick={onClick}
       disabled={disabled}
     >

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import Button from './Button';
+import { XMarkIcon } from '@heroicons/react/24/solid';
 
 type ModalProps = {
   isOpen: boolean;
@@ -38,10 +39,10 @@ const Modal = ({
           <h2 className="text-base font-semibold">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-black text-xl font-bold"
+            className="text-gray-400 hover:text-black text-xl font-bold cursor-pointer"
             aria-label="Close"
           >
-            ×
+            <XMarkIcon className="w-5 h-5" />
           </button>
         </div>
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import Button from './Button';
 
 type ModalProps = {
   isOpen: boolean;
@@ -49,18 +50,12 @@ const Modal = ({
 
         {/* Footer */}
         <div className="flex justify-end gap-2">
-          <button
+          <Button
             onClick={onCancel || onClose}
-            className="px-4 py-2 rounded border border-gray-300 text-sm"
-          >
-            {cancelText}
-          </button>
-          <button
-            onClick={onConfirm}
-            className="px-4 py-2 rounded bg-blue-500 text-white text-sm"
-          >
-            {confirmText}
-          </button>
+            text={cancelText}
+            color="light"
+          />
+          <Button onClick={onConfirm} text={confirmText} color="primary" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용
- 모달창 하단의 버튼을 공통 버튼 컴포넌트로 교체
- 모달창 닫는 버튼을 Heroicons로 교체 및 cursor-pointer 추가

## 참고 사항
- 공통 버튼 컴포넌트의 rounded 수정 및 cursor-pointer 추가