### PR TITLE
[수정] eslint 에러 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import MainPage from './pages/MainPage';
 import ModalTestPage from './pages/ModalTestPage';

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useState } from 'react';
+import { type HTMLAttributes, useState } from 'react';
 import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 
 interface Option {

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import Button from './Button';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import CodeTogetherLogo from '../assets/code_together_logo.png';
 import KakaoLoginLogo from '../assets/kakao_login_medium_wide.png';
 import { CodeBracketIcon, UserGroupIcon } from '@heroicons/react/24/solid';

--- a/src/pages/ModalTestPage.tsx
+++ b/src/pages/ModalTestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Modal from '../components/common/Modal';
 
 const ModalTestPage = () => {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import CodeTogetherLogo from '../assets/code_together_logo.png';
 import {
   ListBulletIcon,


### PR DESCRIPTION
## 작업 내용

배포를 위해 빌드 시 발생하는 에러 제거
- 무의미한 import React 제거
- 타입만 사용되는 인자(HTMLAttributes 등)을 type으로 import 적용