### PR TITLE
[기능] 세션(Session) 도메인 API 연동 및 메인 페이지 연결

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
+#!/bin/sh
 echo "🐶pre-commit hook is working...🐶"
 npx lint-staged

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -23,3 +23,16 @@ export const getSessionList = async (page = 1, limit = 20) => {
 
   return res.data.sessions;
 };
+
+export const joinSession = async (token: string, sessionId: number) => {
+  const res = await axios.post(
+    `${import.meta.env.VITE_API_BASE_URL}/sessions/${sessionId}/join`,
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  return res.data;
+};

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+export const createSession = async (
+  token: string,
+  data: { title: string; mode: string; language: string },
+) => {
+  const res = await axios.post(
+    `${import.meta.env.VITE_API_BASE_URL}/sessions`,
+    data,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  return res.data;
+};
+
+export const getSessionList = async (page = 1, limit = 20) => {
+  const res = await axios.get(
+    `${import.meta.env.VITE_API_BASE_URL}/sessions?page=${page}&limit=${limit}`,
+  );
+
+  return res.data.sessions;
+};

--- a/src/components/mainpage/RoomCard.tsx
+++ b/src/components/mainpage/RoomCard.tsx
@@ -5,7 +5,6 @@ import Label from '../common/Label';
 interface RoomCardProps {
   title: string;
   techStack: string;
-  status: 'active' | 'inactive';
   category: string;
   className?: string;
 }
@@ -13,7 +12,6 @@ interface RoomCardProps {
 const RoomCard: React.FC<RoomCardProps> = ({
   title,
   techStack,
-  status,
   category,
   className = '',
 }) => {
@@ -43,16 +41,7 @@ const RoomCard: React.FC<RoomCardProps> = ({
 
       {/* 상태 및 입장 버튼 */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center">
-          <div
-            className={`w-2 h-2 rounded-full mr-2 ${
-              status === 'active' ? 'bg-green-500' : 'bg-gray-400'
-            }`}
-          />
-          <span className="text-sm text-gray-600 capitalize">
-            {status === 'active' ? '활성' : '비활성'}
-          </span>
-        </div>
+        <div className="flex items-center"></div>
         <Button text="입장하기" color="primary" className="text-sm px-4 py-2" />
       </div>
     </div>

--- a/src/components/mainpage/RoomCard.tsx
+++ b/src/components/mainpage/RoomCard.tsx
@@ -7,6 +7,7 @@ interface RoomCardProps {
   techStack: string;
   category: string;
   className?: string;
+  onJoin?: () => void;
 }
 
 const RoomCard: React.FC<RoomCardProps> = ({
@@ -14,6 +15,7 @@ const RoomCard: React.FC<RoomCardProps> = ({
   techStack,
   category,
   className = '',
+  onJoin,
 }) => {
   return (
     <div
@@ -42,7 +44,12 @@ const RoomCard: React.FC<RoomCardProps> = ({
       {/* 상태 및 입장 버튼 */}
       <div className="flex items-center justify-between">
         <div className="flex items-center"></div>
-        <Button text="입장하기" color="primary" className="text-sm px-4 py-2" />
+        <Button
+          text="입장하기"
+          color="primary"
+          className="text-sm px-4 py-2"
+          onClick={onJoin}
+        />
       </div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+createRoot(document.getElementById('root')!).render(<App />);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -11,20 +11,21 @@ import RoomCard from '../components/mainpage/RoomCard';
 import Button from '../components/common/Button';
 import CreateRoomModal from '../components/mainpage/CreateRoomModal';
 import FilterModal from '../components/mainpage/FilterModal';
-import { createSession, getSessionList } from '../api/session';
+import { createSession, getSessionList, joinSession } from '../api/session';
 
 export interface Session {
   id: number;
   title: string;
   language: string;
   mode: '문제풀이' | '웹편집';
+  isEnded: boolean;
 }
 
 const MainPage: React.FC = () => {
   const [searchValue, setSearchValue] = useState('');
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
-  const [sessionList, setSessionList] = useState([]);
+  const [sessionList, setSessionList] = useState<Session[]>([]);
 
   const fetchSessions = async () => {
     try {
@@ -73,10 +74,27 @@ const MainPage: React.FC = () => {
       const result = await createSession(token, roomData);
       alert(`새 방이 생성되었습니다!\n방 ID: ${result.id}`);
       setIsCreateRoomModalOpen(false);
-      await fetchSessions(); // 방 생성 후 목록 갱신
+      await fetchSessions();
     } catch (error) {
       console.error(error);
       alert('방 생성 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handleJoinSession = async (sessionId: number) => {
+    try {
+      const token = localStorage.getItem('accessToken');
+      if (!token) {
+        alert('로그인이 필요합니다.');
+        return;
+      }
+
+      await joinSession(token, sessionId);
+      alert('세션에 참여했습니다!');
+      // TODO: 세션 상세 페이지로 이동
+    } catch (error) {
+      console.error(error);
+      alert('세션 참여 중 오류가 발생했습니다.');
     }
   };
 
@@ -129,12 +147,13 @@ const MainPage: React.FC = () => {
 
           {/* 동적 방 카드 그리드 */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {sessionList.map((session: Session) => (
+            {sessionList.map((session) => (
               <RoomCard
                 key={session.id}
                 title={session.title}
                 techStack={`</> ${session.language}`}
                 category={session.mode}
+                onJoin={() => handleJoinSession(session.id)}
               />
             ))}
           </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   MagnifyingGlassIcon,
   PlusIcon,
@@ -11,11 +11,33 @@ import RoomCard from '../components/mainpage/RoomCard';
 import Button from '../components/common/Button';
 import CreateRoomModal from '../components/mainpage/CreateRoomModal';
 import FilterModal from '../components/mainpage/FilterModal';
+import { createSession, getSessionList } from '../api/session';
+
+export interface Session {
+  id: number;
+  title: string;
+  language: string;
+  mode: '문제풀이' | '웹편집';
+}
 
 const MainPage: React.FC = () => {
   const [searchValue, setSearchValue] = useState('');
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
+  const [sessionList, setSessionList] = useState([]);
+
+  const fetchSessions = async () => {
+    try {
+      const data = await getSessionList();
+      setSessionList(data);
+    } catch (error) {
+      console.error('세션 목록 조회 실패:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessions();
+  }, []);
 
   const handleSearch = (value: string) => {
     alert(`검색어: ${value}`);
@@ -36,16 +58,26 @@ const MainPage: React.FC = () => {
     setIsFilterModalOpen(false);
   };
 
-  const handleCreateRoom = (roomData: {
+  const handleCreateRoom = async (roomData: {
     title: string;
     mode: string;
     language: string;
   }) => {
-    console.log('새 방 생성:', roomData);
-    alert(
-      `새 방이 생성되었습니다!\n제목: ${roomData.title}\n모드: ${roomData.mode}\n언어: ${roomData.language}`,
-    );
-    setIsCreateRoomModalOpen(false);
+    try {
+      const token = localStorage.getItem('accessToken');
+      if (!token) {
+        alert('로그인이 필요합니다.');
+        return;
+      }
+
+      const result = await createSession(token, roomData);
+      alert(`새 방이 생성되었습니다!\n방 ID: ${result.id}`);
+      setIsCreateRoomModalOpen(false);
+      await fetchSessions(); // 방 생성 후 목록 갱신
+    } catch (error) {
+      console.error(error);
+      alert('방 생성 중 오류가 발생했습니다.');
+    }
   };
 
   return (
@@ -73,7 +105,6 @@ const MainPage: React.FC = () => {
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-2xl font-bold text-gray-900">활성 방 목록</h2>
             <div className="flex items-center gap-4">
-              {/* 검색 필드 */}
               <TextField
                 placeholder="방 제목 검색..."
                 value={searchValue}
@@ -85,8 +116,7 @@ const MainPage: React.FC = () => {
                 }}
                 icon={<MagnifyingGlassIcon className="w-5 h-5" />}
                 className="w-64"
-              />{' '}
-              {/* 필터 버튼 */}
+              />
               <Button
                 icon={<FunnelIcon className="w-4 h-4" />}
                 text="필터"
@@ -97,47 +127,19 @@ const MainPage: React.FC = () => {
             </div>
           </div>
 
-          {/* 방 카드 그리드 */}
+          {/* 동적 방 카드 그리드 */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <RoomCard
-              title="알고리즘 스터디 - 백준 문제풀이"
-              techStack="</> Python"
-              status="active"
-              category="문제풀이"
-            />
-            <RoomCard
-              title="React 프로젝트 협업"
-              techStack="</> JavaScript"
-              status="active"
-              category="웹편집"
-            />
-            <RoomCard
-              title="Java 기초 학습"
-              techStack="</> Java"
-              status="active"
-              category="문제풀이"
-            />
-            <RoomCard
-              title="웹 개발 프로젝트"
-              techStack="</> HTML/CSS"
-              status="active"
-              category="웹편집"
-            />
-            <RoomCard
-              title="Python 데이터 분석"
-              techStack="</> Python"
-              status="active"
-              category="문제풀이"
-            />
-            <RoomCard
-              title="Node.js 백엔드 개발"
-              techStack="</> JavaScript"
-              status="active"
-              category="웹편집"
-            />
+            {sessionList.map((session: Session) => (
+              <RoomCard
+                key={session.id}
+                title={session.title}
+                techStack={`</> ${session.language}`}
+                category={session.mode}
+              />
+            ))}
           </div>
 
-          {/* 더 많은 방 보기 버튼 */}
+          {/* 더 많은 방 보기 */}
           <div className="text-center mt-8">
             <Button
               text="더 많은 방 보기"
@@ -149,14 +151,12 @@ const MainPage: React.FC = () => {
       </main>
       <Footer />
 
-      {/* 새 방 만들기 모달 */}
       <CreateRoomModal
         isOpen={isCreateRoomModalOpen}
         onClose={() => setIsCreateRoomModalOpen(false)}
         onConfirm={handleCreateRoom}
       />
 
-      {/* 필터 모달 */}
       <FilterModal
         isOpen={isFilterModalOpen}
         onClose={() => setIsFilterModalOpen(false)}


### PR DESCRIPTION
### 작업 내용
- `GET /sessions`: 세션 목록 조회 API 연동
  - 메인 페이지 진입 시 세션 리스트를 불러와 카드 형태로 표시
- `POST /sessions`: 세션 생성 API 연동
  - "새 방 만들기" 모달을 통해 입력한 데이터로 세션 생성 요청
  - 생성 성공 시 리스트 자동 갱신
- `POST /sessions/:id/join`: 세션 참여 API 연동
  - 참여하기 버튼 클릭 시 해당 세션에 참여 요청 전송

### UI 연결
- `RoomCard` 컴포넌트에 `onJoin` 핸들러 추가
- 참여 성공 시 알림 표시 (추후 세션 페이지 라우팅으로 확장 예정)
- `MainPage.tsx` 내 상태 관리 및 동적 리스트 렌더링 처리

### 기타
- `Session` 인터페이스 정의 및 타입 적용
- `getSessionList`, `createSession`, `joinSession` API 함수 분리 및 추가

### 참고 사항
- 아직 참여 성공 시 세션 페이지 이동은 구현되지 않았으며, 추후 에디터 화면과 함께 연동 예정입니다.
